### PR TITLE
Update tests to use Pester 5 (#4)

### DIFF
--- a/SampleModule.depend.psd1
+++ b/SampleModule.depend.psd1
@@ -1,6 +1,6 @@
 @{
     # Build dependencies
-    Pester                     = @{ target = 'CurrentUser'; version = '4.10.1' }
+    Pester                     = @{ target = 'CurrentUser'; version = 'latest' }
     PSScriptAnalyzer           = @{ target = 'CurrentUser'; version = 'latest' }
     PlatyPS                    = @{ target = 'CurrentUser'; version = 'latest' }
 }

--- a/SampleModule/Public/Get-RandomGuid.Tests.ps1
+++ b/SampleModule/Public/Get-RandomGuid.Tests.ps1
@@ -1,14 +1,17 @@
-$here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
-. "$here\$sut"
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    $sut = (Split-Path -Leaf $PSCommandPath) -replace '\.Tests\.', '.'
+    . "$here\$sut"
+}
 
 Describe "'Get-RandomGuid' Function Functional Tests" {
 
     Context "Accepting input data" {
-
-        #region Arrange
-        $inputData = 10
-        #endregion
+        BeforeAll {
+            #region Arrange
+            $inputData = 10
+            #endregion
+        }
 
         #region Act&Assert
         It "should accept input from the parameter" {
@@ -22,5 +25,4 @@ Describe "'Get-RandomGuid' Function Functional Tests" {
         }
         #endregion
     }
-
 }

--- a/SampleModule/SampleModule.Tests.ps1
+++ b/SampleModule/SampleModule.Tests.ps1
@@ -1,12 +1,15 @@
-﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+﻿BeforeAll {
+  # For use within the tests, during the Run phase
+  $here = Split-Path -Parent $PSCommandPath
 
-#region Reloading SUT
-# Ensuring that we are testing this version of module and not any other version that could be in memory
-$modulePath = "$($MyInvocation.MyCommand.Path -replace '.Tests.ps1$', '').psm1"
-$moduleName = (($modulePath | Split-Path -Leaf) -replace '.psm1')
-@(Get-Module -Name $moduleName).where({ $_.version -ne '0.0' }) | Remove-Module # Removing all module versions from the current context if there are any
-Import-Module -Name $modulePath -Force -ErrorAction Stop # Loading module explicitly by path and not via the manifest
-#endregion
+  #region Reloading SUT
+  # Ensuring that we are testing this version of module and not any other version that could be in memory
+  $modulePath = "$($PSCommandPath -replace '.Tests.ps1$', '').psm1"
+  $moduleName = (($modulePath | Split-Path -Leaf) -replace '.psm1')
+  @(Get-Module -Name $moduleName).where({ $_.version -ne '0.0' }) | Remove-Module # Removing all module versions from the current context if there are any
+  Import-Module -Name $modulePath -Force -ErrorAction Stop # Loading module explicitly by path and not via the manifest
+  #endregion
+}
 
 Describe "'$moduleName' Module Tests" {
 
@@ -44,6 +47,11 @@ Describe "'$moduleName' Module Tests" {
   }
 }
 
+# Duplicated from the BeforeAll above.
+# Implicitly runs during Discovery, required to populate
+# $functionPaths for Pester to properly generate the tests
+$here = Split-Path -Parent $PSCommandPath
+
 # Dynamically defining the functions to test
 $functionPaths = @()
 if (Test-Path -Path "$here\Private\*.ps1") {
@@ -53,67 +61,74 @@ if (Test-Path -Path "$here\Public\*.ps1") {
   $functionPaths += Get-ChildItem -Path "$here\Public\*.ps1" -Exclude "*.Tests.*"
 }
 
+Describe "'<_>' Function Tests" -ForEach $functionPaths {
+  BeforeDiscovery {
+      # Required in order to populate $parameters during discovery to find all parameters
+      # Getting function
+      $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::ParseInput((Get-Content -raw $_), [ref]$null, [ref]$null)
+      $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
+      $ParsedFunction = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) | Where-Object Name -eq $_.BaseName
 
-# Running the tests for each function
-foreach ($functionPath in $functionPaths) {
+      # Getting the list of function parameters
+      $parameters = @($ParsedFunction.Body.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() })
+  }
 
-  $functionName = $functionPath.BaseName
+  BeforeAll {
+    $functionName = $_.BaseName
+    $functionPath = $_
+  }
 
-  Describe "'$functionName' Function Tests" {
-    Context "Function Code Style Tests" {
-      It "should be an advanced function" {
-        $functionPath | Should -FileContentMatch 'Function'
-        $functionPath | Should -FileContentMatch 'CmdletBinding'
-        $functionPath | Should -FileContentMatch 'Param'
-      }
-
-      It "should contain Write-Verbose blocks" {
-        $functionPath | Should -FileContentMatch 'Write-Verbose'
-      }
-
-      It "should be a valid PowerShell code" {
-        $psFile = Get-Content -Path $functionPath -ErrorAction Stop
-        $errors = $null
-        $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
-        $errors.Count | Should -Be 0
-      }
-
-      It "should have tests" {
-        Test-Path ($functionPath -replace ".ps1", ".Tests.ps1") | Should -Be $true
-        ($functionPath -replace ".ps1", ".Tests.ps1") | Should -FileContentMatch "Describe `"'$functionName'"
-      }
+  Context "Function Code Style Tests" {
+    It "should be an advanced function" {
+      $functionPath | Should -FileContentMatch 'Function'
+      $functionPath | Should -FileContentMatch 'CmdletBinding'
+      $functionPath | Should -FileContentMatch 'Param'
     }
 
-    Context "Function Help Quality Tests" {
+    It "should contain Write-Verbose blocks" {
+      $functionPath | Should -FileContentMatch 'Write-Verbose'
+    }
+
+    It "should be a valid PowerShell code" {
+      $psFile = Get-Content -Path $functionPath -ErrorAction Stop
+      $errors = $null
+      $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
+      $errors.Count | Should -Be 0
+    }
+
+    It "should have tests" {
+      Test-Path ($functionPath -replace ".ps1", ".Tests.ps1") | Should -Be $true
+      ($functionPath -replace ".ps1", ".Tests.ps1") | Should -FileContentMatch "Describe `"'$functionName'"
+    }
+  }
+
+  Context "Function Help Quality Tests" {
+    BeforeAll {
       # Getting function help
-      $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::
-      ParseInput((Get-Content -raw $functionPath), [ref]$null, [ref]$null)
+      $AbstractSyntaxTree = [System.Management.Automation.Language.Parser]::ParseInput((Get-Content -raw $functionPath), [ref]$null, [ref]$null)
       $AstSearchDelegate = { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }
       $ParsedFunction = $AbstractSyntaxTree.FindAll( $AstSearchDelegate, $true ) | Where-Object Name -eq $functionName
       $functionHelp = $ParsedFunction.GetHelpContent()
+    }
 
-      It "should have a SYNOPSIS" {
-        $functionHelp.Synopsis | Should -Not -BeNullOrEmpty
-      }
+    It "should have a SYNOPSIS" {
+      $functionHelp.Synopsis | Should -Not -BeNullOrEmpty
+    }
 
-      It "should have a DESCRIPTION with length > 40 symbols" {
-        $functionHelp.Description.Length | Should -BeGreaterThan 40
-      }
+    It "should have a DESCRIPTION with length > 40 symbols" {
+      $functionHelp.Description.Length | Should -BeGreaterThan 40
+    }
 
-      It "should have at least one EXAMPLE" {
-        $functionHelp.Examples.Count | Should -BeGreaterThan 0
-        $functionHelp.Examples[0] | Should -Match ([regex]::Escape($functionName))
-        $functionHelp.Examples[0].Length | Should -BeGreaterThan ($functionName.Length + 10)
-      }
+    It "should have at least one EXAMPLE" {
+      $functionHelp.Examples.Count | Should -BeGreaterThan 0
+      $functionHelp.Examples[0] | Should -Match ([regex]::Escape($functionName))
+      $functionHelp.Examples[0].Length | Should -BeGreaterThan ($functionName.Length + 10)
+    }
 
-      # Getting the list of function parameters
-      $parameters = $ParsedFunction.Body.ParamBlock.Parameters.name.VariablePath.Foreach{ $_.ToString() }
-
-      foreach ($parameter in $parameters) {
-        It "should have descriptive help for '$parameter' parameter" {
-          $functionHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
-          $functionHelp.Parameters.($parameter.ToUpper()).Length | Should -BeGreaterThan 25
-        }
+    $parameters | ForEach-Object {
+      It "should have descriptive help for '<parameter>' parameter" -TestCases @{parameter = $_} {
+        $functionHelp.Parameters.($parameter.ToUpper()) | Should -Not -BeNullOrEmpty
+        $functionHelp.Parameters.($parameter.ToUpper()).Length | Should -BeGreaterThan 25
       }
     }
   }


### PR DESCRIPTION
* Update tests to use Pester 5

Update Pester dependency to the latest
Remove importing specific Pester version
Made all tests pass with Pester 5 (trying as best as I can to utilize the intended use cases of Pester's new Discovery and Run phases along with the already existing setup)

* Fix failing test due to Scoping issue

* Update Test and CodeCoverage tasks to align with Pester 5

* Fix incorrect character

The dash used is not a regular hyphen but appears to be an emdash. Fixes this warning: The character U+2013 "–" could be confused with the character U+002d "-"

* Fix Analyze task for Pester 5

Also go back through the Test task and adjust a few more settings.

* Flatten Analyze test files retrieval