### PR TITLE
Decide version before workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
       - '*.md'
       - '.gitignore'
       - 'LICENSE'
+      - 'CODEOWNERS'
     branches:
       - main
     tags:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @beau-witter

--- a/NetworkAnalyzer/NetworkAnalyzer.psd1
+++ b/NetworkAnalyzer/NetworkAnalyzer.psd1
@@ -12,7 +12,7 @@
 RootModule = 'NetworkAnalyzer.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.5'
+ModuleVersion = '0.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'


### PR DESCRIPTION
This now needs to happen prior to commiting instead of in the workflow. This way the version in the manifest is the same as the generated version to avoid confusion.