### PR TITLE
Let Invoke-Build decide version before workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
       - '*.md'
       - '.gitignore'
       - 'LICENSE'
+      - 'CODEOWNERS'
     branches:
       - main
     tags:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @beau-witter

--- a/NetworkAnalyzer/NetworkAnalyzer.psd1
+++ b/NetworkAnalyzer/NetworkAnalyzer.psd1
@@ -12,7 +12,7 @@
 RootModule = 'NetworkAnalyzer.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.5'
+ModuleVersion = '0.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'


### PR DESCRIPTION
No longer generate build number outside of SC in the workflow. Do have to remember to run this before intended publishes.